### PR TITLE
rename ITI-104

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,3 @@
 Next steps:
 [ ] Profile for which elements are necessary to do a patent identity feed -> [ITI-105] ?
-[ ] Naming conflict [ITI-93] and [ITI-104] : Mobile Patient Identity Feed [ITI-93] -> Mobile Patient Identifier Cross-Reference Feed [ITI-104]
 [ ] Add to [ITI-104] transaction the Delete Patient operation -> Optional because of PIX V2, V3 grouping

--- a/input/images-source/ActorsAndTransactions.plantuml
+++ b/input/images-source/ActorsAndTransactions.plantuml
@@ -5,7 +5,7 @@ agent "Patient Identifier Cross-reference Consumer" as Consumer
 agent "Patient Identifier Cross-reference Manager" as Manager
 
 
-Source --- Manager: "Mobile Patient Identifier Structure Definition [ITI-105]↓\n Mobile Patient Identity Feed [ITI-104]↓"
+Source --- Manager: "Mobile Patient Identifier Structure Definition [ITI-105]↓\n Mobile Patient Identifier Cross-Reference Feed [ITI-104]↓"
 Consumer -- Manager : "Mobile Patient Identifier Structure Definition [ITI-105]↓\n Mobile Patient Identifier Cross-reference Query [ITI-83]↓"
 
 @enduml

--- a/input/implementationguide-IHE_PIXm.xml
+++ b/input/implementationguide-IHE_PIXm.xml
@@ -145,7 +145,7 @@
       </page>
       <page>
         <nameUrl value="ITI-104.html"/>
-        <title value="3.104 Mobile Patient Identity Feed [ITI-104]"/>
+        <title value="3.104 Mobile Patient Identifier Cross-Reference Feed [ITI-104]"/>
         <generation value="markdown"/>
       </page>
 						<page>

--- a/input/includes/menu.xml
+++ b/input/includes/menu.xml
@@ -42,7 +42,7 @@
         <a href="ITI-83.html">Patient Identity cross-Reference Query [ITI-83]</a>
       </li>
       <li>
-        <a href="ITI-104.html">Mobile Patient Identity Feed [ITI-104]</a>
+        <a href="ITI-104.html">Mobile Patient Identifier Cross-Reference Feed [ITI-104]</a>
       </li>
       <li>
         <a href="ITI-105.html">Patient Identity cross-Reference Structure Definition [ITI-105]</a>

--- a/input/pagecontent/ITI-104.md
+++ b/input/pagecontent/ITI-104.md
@@ -1,4 +1,4 @@
-<!-- 3.104 Mobile Patient Identity Feed [ITI-104] -->
+<!-- 3.104 Mobile Patient Identifier Cross-Reference Feed [ITI-104] -->
 
 This section corresponds to transaction [ITI-104] of the IHE Technical Framework. Transaction [ITI-104] is used by the Patient Identity Source and Patient Identifier Cross-reference Manager.
 

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -26,7 +26,7 @@ This guide is organized into four main sections:
 
 2. Volume II: Transaction Detail
    1. [Patient Identifier Cross-Reference Query [ITI-83]](ITI-83.html)
-   2. [Mobile Patient Identity Feed [ITI-104]](ITI-104.html)
+   2. [Mobile Patient Identifier Cross-Reference Feed [ITI-104]](ITI-104.html)
    3. [Patient Identity cross-Reference Structure Definition [ITI-105]](ITI-105.html)
 
 

--- a/input/pagecontent/volume-1.md
+++ b/input/pagecontent/volume-1.md
@@ -10,7 +10,7 @@
 
 * Transactions
   - [Patient Identity Cross-Reference Query [ITI-83]](ITI-83.html)
-  - [Mobile Patient Identity Feed [ITI-104]](ITI-104.html)
+  - [Mobile Patient Identifier Cross-Reference Feed [ITI-104]](ITI-104.html)
   - [Patient Identity cross-Reference Structure Definition [ITI-105]](ITI-105.html)
 
 Figure below shows the actors directly involved in the PIXm Profile and the relevant transactions between them.
@@ -29,18 +29,16 @@ Table 41.1-1: PIXm Profile - Actors and Transactions
 
 | Actors| Transactions| Initiator or Responder | Optionality | Reference |
 | ----- | ----------- | ---------------------- | ----------- | --------- |
-| Patient Identifier Cross-reference Source | Mobile Patient Identity Feed \[ITI-104\] | Initiator | R | [ITI TF-2: 3.104](ITI-104.html) |
+| Patient Identifier Cross-reference Source | Mobile Patient Identifier Cross-Reference Feed \[ITI-104\] | Initiator | R | [ITI TF-2: 3.104](ITI-104.html) |
 | | Mobile Patient Identifier Cross-Reference Structure Definition [ITI-105]| Initiator | O | [ITI TF-2: 3.105](ITI-105.html) |
 | Patient Identifier Cross-reference Consumer | Mobile Patient Identifier Cross-Reference Query [ITI-83] | Initiator | R | [ITI TF-2: 3.83](ITI-83.html) |
 | | Mobile Patient Identifier Cross-Reference Structure Definition [ITI-105]| Initiator| O | [ITI TF-2: 3.105](ITI-105.html) |
 | Patient Identifier Cross-reference Manager  | Mobile Patient Identifier Cross-Reference Query [ITI-83] | Responder | R | [ITI TF-2: 3.83](ITI-83.html) |
-| | Mobile Patient Identity Feed [ITI-104] | Responder | R | [ITI TF-2: 3.104](ITI-104.html) |
+| | Mobile Patient Identifier Cross-Reference Feed [ITI-104] | Responder | R | [ITI TF-2: 3.104](ITI-104.html) |
 | | Mobile Patient Identifier Cross-Reference Structure Definition [ITI-105] | Responder | R | [ITI TF-2: 3.105](ITI-105.html) |
 {: .grid }
 
-The Mobile Patient Identity Feed [ITI-104] and the Mobile Patient Identifier Cross-Reference Query [ITI-83] transactions
-defined in this profile correspond to the transactions used in the PIX and PIXV3 Profiles (ITI TF-1: 5 and 23) and provide
-similar functionality.
+The Mobile Patient Identifier Cross-Reference Feed [ITI-104] and the Mobile Patient Identifier Cross-Reference Query [ITI-83] transactions defined in this profile correspond to the transactions used in the PIX and PIXV3 Profiles (ITI TF-1: 5 and 23) and provide similar functionality.
 
 ##### 41.1.1.1 Patient Identifier Cross-reference Source
 The Patient Identifier Cross-reference Source is the producer and publisher of patient identity data.
@@ -96,19 +94,11 @@ Identifier Cross-Reference Manager and a transaction to retrieve the FHIR struct
 
 #### 41.4.1 Concepts
 
-This profile uses RESTful transaction and FHIR patient resources for the Mobile Patient Identity Feed [ITI-104] and Mobile
-Patient Identifier Cross-Reference Query [ITI-83] transactions performed by the Patient Identifier Cross-Reference Source
-and Manager actors and a Mobile Patient Identifier Cross-Reference Structure Definition [ITI-105] transaction to share the
-structure definition of the FHIR patient resource.   
+This profile uses RESTful transaction and FHIR patient resources for the Mobile Patient Identifier Cross-Reference Feed [ITI-104] and Mobile Patient Identifier Cross-Reference Query [ITI-83] transactions performed by the Patient Identifier Cross-Reference Source and Manager actors and a Mobile Patient Identifier Cross-Reference Structure Definition [ITI-105] transaction to share the structure definition of the FHIR patient resource.   
 
-This profile assumes that the Patient Identifier Cross-Reference Manager performs linking and unlinking based on the
-patient identity data provided in the Mobile Patient Identity Feed [ITI-104] transactions from different patient domains.
+This profile assumes that the Patient Identifier Cross-Reference Manager performs linking and unlinking based on the patient identity data provided in the Mobile Patient Identifier Cross-Reference Feed [ITI-104] transactions from different patient domains.
 
-This profile does neither specify the rules and algorithm applied by the Patient Identifier Cross-Reference Manager actor
-to link or unlink the patient identity data from different domains, nor the point in time the Patient Identifier Cross-
-Reference Manager actually links the data. Patient Identifier Cross-Reference Manager may link the patient identity data
-from the different domains on time of the Mobile Patient Identity Feed [ITI-104] transactions, but also may provide other
-triggers (e.g., manual linking or unlinking in case when the rules and algorithms go wrong).
+This profile does neither specify the rules and algorithm applied by the Patient Identifier Cross-Reference Manager actor to link or unlink the patient identity data from different domains, nor the point in time the Patient Identifier Cross-Reference Manager actually links the data. Patient Identifier Cross-Reference Manager may link the patient identity data from the different domains on time of the Mobile Patient Identifier Cross-Reference Feed [ITI-104] transactions, but also may provide other triggers (e.g., manual linking or unlinking in case when the rules and algorithms go wrong).
 
 This profile does not address issues related to building 'golden records' or verified patient identity data. Patient
 Identifier Cross-Reference Managers may add business functionality to support 'golden records' or verified patient identity
@@ -130,7 +120,7 @@ license number ‘E-123’ as their local patient ID. Before requesting the alle
 it must translate the known patient identity (driver’s license) to the patient’s identity known by the hospital (MRN).
 
 To achieve this correlation, the mobile Care system first registers the patient identity data including the local ID
-(driver’s license number ‘E-123’) using the Mobile Patient Identity Feed [ITI-104] transaction. The mobile Care system
+(driver’s license number ‘E-123’) using the Mobile Patient Identifier Cross-Reference Feed [ITI-104] transaction. The mobile Care system
 then issues a Mobile Patient Identifier Cross-reference Query [ITI-83] to the Patient Identifier Cross-reference Manager to
 retrieve the list of patient ID aliases from the Patient Identifier Cross-reference Manager assigned to the same patient
 person.
@@ -156,8 +146,12 @@ After finishing the medical treatment the healthcare professional of the ambulan
 domains (e.g., the allergy system). Having registered the patient identity data including the local patient ID (‘E-123’)
 the mobile Care systems can provide documents and register them with the mobile Care system local ID (‘E-123’).
 
+<<<<<<< HEAD
 Healthcare systems of other domains may retrieve the documents by using a Mobile Patient Identity Feed [ITI-104] of their
 local patient identity data and retrieving the list of patient ID's from the other domains as explained in section above.
+=======
+Healthcare systems of other domains may retrieve the documents by using a Mobile Patient Identifier Cross-Reference Feed [ITI-104] of their local patient identity data and retrieving the list of patient ID's from the other domains as explained in section above.
+>>>>>>> rename ITI-104
 
 ###### 41.4.2.2.2 Process Flow
 Intentionally left blanc.


### PR DESCRIPTION
Naming conflict [ITI-93] and [ITI-104] : Mobile Patient Identity Feed [ITI-93] in PMIR is called the same name as now in [ITI-104]. However with introducing the RESTFul interactions instead of a Message the transaction changes. Suggestion to rename the transaction to: Mobile Patient Identifier Cross-Reference Feed [ITI-104]
