### PR TITLE
Option 'Delete Support on Server for Source and Manager

### DIFF
--- a/input/pagecontent/ITI-104.md
+++ b/input/pagecontent/ITI-104.md
@@ -32,7 +32,7 @@ The roles in this transaction are defined in the following table and may be play
 
 A Patient Identity Source notifies the Patient Identifier Cross-reference Manager that a patient has been [added or revised](#2310441-add-or-revise-patient) in the Patient Identity Source.
 The Patient Identity Source notifies the Patient Identifier Cross-reference Manager that [duplicate records](#2310442-resolve-duplicate-patient) were resolved in the Patient Identity Source.
-If the [Remove Patient Option](volume-1.html#14121-delete-support-on-server) is supported the Patient Identity Source notifies the Patient Identifier Cross-reference Manager that [a patient record was removed](#2310443-remove-patient) in the Patient Identity Source.
+If the [Remove Patient Option](volume-1.html#14121-remove-patient) is supported the Patient Identity Source notifies the Patient Identifier Cross-reference Manager that [a patient record was removed](#2310443-remove-patient) in the Patient Identity Source.
 
 #### 2:3.104.4.1 Add or Revise Patient
 
@@ -214,7 +214,7 @@ Content-Type: application/fhir+json
 
 #### 2:3.104.4.3 Remove Patient 
 
-This message enables the removal of patient identity data if the [Remove Patient Option](volume-1.html#14121-delete-support-on-server) is supported.
+This message enables the removal of patient identity data if the [Remove Patient Option](volume-1.html#14121-remove-patient) is supported.
 
 This message is implemented as an HTTP conditional delete operation from the Patient Identity Source to the Patient Identifier
 Cross-reference Manager described in Section 3.104.4.3.2 Message Semantics. 

--- a/input/pagecontent/volume-1.md
+++ b/input/pagecontent/volume-1.md
@@ -326,7 +326,7 @@ Patient Identity Feed FHIR [ITI-104] transactions to the
 more traditional PIX and PIXV3 Query and Feed transactions,
 thus acting as a proxy to the Patient Identifier Cross-reference Manager that
 wants to enable RESTful transactions. Note that PIX and PIX V3 Source Actors do not have
-a corresponding [Remove Patient Option](#14121-delete-support-on-server).
+a corresponding [Remove Patient Option](#14121-remove-patient).
 
 ### 1:41.6.2 Use with the Internet User Authorization (IUA) Profile  
 The IUA Profile provides support for user authentication, app authentication, and authorization decisions. When PIXm actors are grouped with IUA actors there are additional security and privacy functionality enabled by this grouping. There are additional requirements and functionality enabled through scope definitions that are transaction-specific. See the Security Considerations sections of the PIXm-defined transactions for guidance on scope definition when grouped with IUA actors.


### PR DESCRIPTION
Added named option 'Delete Support on Server' for Patient Identity Source and Patient Identifier Cross-reference Manager as discussed for #74.